### PR TITLE
Fix THE INFAMOUS MEMORY LEAK

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2667,10 +2667,8 @@ class Level implements ChunkManager, Metadatable{
 		if($entity instanceof Player){
 			unset($this->players[$entity->getId()]);
 			$this->checkSleep();
-		}elseif($entity instanceof ExperienceOrb){
-			$entity->close();
 		}else{
-			$entity->kill();
+			$entity->close();
 		}
 
 		unset($this->entities[$entity->getId()]);


### PR DESCRIPTION
This commit, simple though it looks, fixes the horrible memory leak that PocketMine and all its forks have been suffering from since forever. Tested this on Genisys and it works flawlessly.
