### PR TITLE
Fix %0 client translation exploit

### DIFF
--- a/src/pocketmine/lang/BaseLang.php
+++ b/src/pocketmine/lang/BaseLang.php
@@ -72,7 +72,7 @@ class BaseLang{
 			$baseText = str_replace("{%$i}", $this->parseTranslation((string) $p), $baseText, $onlyPrefix);
 		}
 
-		return $baseText;
+		return str_replace("%0", "", $baseText); //fixes a client bug where %0 in translation will cause freeze
 	}
 
 	public function translate(TextContainer $c){


### PR DESCRIPTION
Patches a client bug where sending a TextPacket with type TYPE_TRANSLATION would freeze/crash the client when the translation string contained %0

References: 
https://github.com/iTXTech/Genisys/pull/1630
https://github.com/iTXTech/Genisys/issues/1583

(Yes, I cherry-picked my own commit.)
