### PR TITLE
Network: Do not attempt to decode further for non-accepted protocols

### DIFF
--- a/src/pocketmine/network/protocol/LoginPacket.php
+++ b/src/pocketmine/network/protocol/LoginPacket.php
@@ -18,6 +18,9 @@ class LoginPacket extends DataPacket{
 	public $xboxData = null;
 	public function decode(){
 		$this->protocol = $this->getInt();
+		if(!in_array($this->protocol, Info::ACCEPTED_PROTOCOLS)){
+			return; //Do not attempt to decode for non-accepted protocols
+		}
 		$str = zlib_decode($this->get($this->getInt()), 1024 * 1024 * 64); //Max 64MB
 		$this->setBuffer($str, 0);
 		$chainData = json_decode($this->get($this->getLInt()));


### PR DESCRIPTION
Prevents 0.16 players causing error spam on 0.15 servers
