### PR TITLE
Remove 81+82 protocol version and add 84

### DIFF
--- a/src/pocketmine/network/protocol/Info.php
+++ b/src/pocketmine/network/protocol/Info.php
@@ -11,9 +11,9 @@ interface Info{
 	 * Actual Minecraft: PE protocol versions
 	 */
 	const CURRENT_PROTOCOL = 83;
-	const ACCEPT_PROTOCOL = [81,82,83];
+	const ACCEPT_PROTOCOL = [83, 84];
 	const CURRENT_VERSION = "0.15";
-	
+
 	const LOGIN_PACKET = 0x01;
 	const PLAY_STATUS_PACKET = 0x02;
 	const SERVER_TO_CLIENT_HANDSHAKE_PACKET = 0x03;
@@ -79,14 +79,3 @@ interface Info{
 	const REPLACE_SELECTED_ITEM_PACKET = 0x40;
 	const ADD_ITEM_PACKET = 0x41;
 }
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
**Why removing 81+82 from accepted protocols?**
Because of the capes (new skinids) added into the 0.15.9 update which also updated the protocol version to 83. Old clients would crash.

**Why adding 84 to the accepted protocols?**
84 is the protocol version of the 0.15.10 update which just came out.
