### PR TITLE
Fix DoS with empty packets does not trigger blocking

### DIFF
--- a/src/raklib/server/SessionManager.php
+++ b/src/raklib/server/SessionManager.php
@@ -141,7 +141,8 @@ class SessionManager{
 
 
     private function receivePacket(){
-        if(($len = $this->socket->readPacket($buffer, $source, $port)) > 0){
+        $len = $this->socket->readPacket($buffer, $source, $port);
+        if($buffer !== null){
             $this->receiveBytes += $len;
             if(isset($this->block[$source])){
                 return true;
@@ -153,30 +154,33 @@ class SessionManager{
                 $this->ipSec[$source] = 1;
             }
 
-            $pid = ord($buffer{0});
+            if($len > 0){
+                $pid = ord($buffer{0});
 
-            if($pid === UNCONNECTED_PING::$ID){
-                //No need to create a session for just pings
-                $packet = new UNCONNECTED_PING;
-                $packet->buffer = $buffer;
-                $packet->decode();
+                if($pid === UNCONNECTED_PING::$ID){
+                    //No need to create a session for just pings
+                    $packet = new UNCONNECTED_PING;
+                    $packet->buffer = $buffer;
+                    $packet->decode();
 
-                $pk = new UNCONNECTED_PONG();
-                $pk->serverID = $this->getID();
-                $pk->pingID = $packet->pingID;
-                $pk->serverName = $this->getName();
-                $this->sendPacket($pk, $source, $port);
-            }elseif($pid === UNCONNECTED_PONG::$ID){
-                //ignored
-            }elseif(($packet = $this->getPacketFromPool($pid)) !== null){
-                $packet->buffer = $buffer;
-                $this->getSession($source, $port)->handlePacket($packet);
-            }else{
-                $this->streamRaw($source, $port, $buffer);
+                    $pk = new UNCONNECTED_PONG();
+                    $pk->serverID = $this->getID();
+                    $pk->pingID = $packet->pingID;
+                    $pk->serverName = $this->getName();
+                    $this->sendPacket($pk, $source, $port);
+                }elseif($pid === UNCONNECTED_PONG::$ID){
+                    //ignored
+                }elseif(($packet = $this->getPacketFromPool($pid)) !== null){
+                    $packet->buffer = $buffer;
+                    $this->getSession($source, $port)->handlePacket($packet);
+                }else{
+                    $this->streamRaw($source, $port, $buffer);
+                }
             }
+            return true;
         }
 
-        return $buffer !== null;
+        return false;
     }
 
     public function sendPacket(Packet $packet, $dest, $port){


### PR DESCRIPTION
DoS with empty packets did not trigger address blocking before this patch. Not a hugely critical issue, but still a bug.
